### PR TITLE
Also include .ipp files in BUILD.bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,6 +6,7 @@ cc_library(
     name = "boost.beast",
     hdrs = glob([
         "include/**/*.hpp",
+        "include/**/*.ipp",
         "include/**/*.h",
     ]),
     includes = ["include"],


### PR DESCRIPTION
This aims to address https://github.com/bazelboost/beast/issues/1. Tested that the build succeeds with a [git_override](https://bazel.build/rules/lib/globals/module#git_override) to this change and fails without.

The idea for the fix comes from the difference between the changes on the [beast bazelboost-1.83.0](https://github.com/boostorg/beast/compare/develop...bazelboost:beast:bazelboost-1.83.0) branch and the [asio bazelboost-1.83.0](https://github.com/boostorg/asio/compare/develop...bazelboost:asio:bazelboost-1.83.0) branch.